### PR TITLE
feat: add field map adapter and API skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/dist
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # Ganttron
-Typescript gantt chart for viewing project schedules.
+
+Ganttron is a TypeScript library for rendering view only Gantt charts for Metron
+schedule snapshots.  The goal of the project is to provide a fast and accessible
+Gantt viewer that consumes the server generated JSON directly.  The initial
+implementation included here focuses on the **Field Map Adapter** used to keep
+the library schema‑evolution safe.
+
+## Field Map Adapter
+
+Metron snapshot JSON may evolve over time.  Ganttron exposes a configurable
+`FieldMap` that describes how to read important fields from tasks, WBS nodes and
+relationships.  Each field can provide a list of aliases or a resolver function.
+When new field names are introduced callers can pass a partial map with the new
+aliases without upgrading the library.
+
+```ts
+import { mergeFieldMap, normalizeSnapshot } from 'ganttron';
+
+const snapshot = fetch('/snapshot.json');
+const map = mergeFieldMap({
+  task: { id: ['task_id', 'id'], name: ['task_name', 'name'] }
+});
+const norm = normalizeSnapshot(snapshot, map);
+```
+
+The default map supports today’s Metron field names and the adapter resolves the
+first non‑empty alias in each list.
+
+## Creating a Ganttron instance
+
+```ts
+import { createGanttron } from 'ganttron';
+
+const gt = createGanttron({
+  container: document.getElementById('gantt')!,
+  mode: 'view',
+  data: snapshotJson
+});
+```
+
+The current build contains stub implementations for the rendering layer but
+establishes the public API and data normalisation logic described in the design
+specification.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ganttron",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.2",
+    "vitest": "^1.3.1",
+    "tslib": "^2.6.2"
+  }
+}

--- a/src/adapters/field-map.ts
+++ b/src/adapters/field-map.ts
@@ -1,0 +1,233 @@
+export interface FieldResolvers {
+  id: string[] | ((t: any) => string);
+  name: string[] | ((t: any) => string);
+  wbsId: string[] | ((t: any) => string);
+  start: string[] | ((t: any) => string | number | Date);
+  finish: string[] | ((t: any) => string | number | Date);
+  durationDays?: string[] | ((t: any) => number);
+  durationHours?: string[] | ((t: any) => number);
+  percentComplete?: string[] | ((t: any) => number);
+  critical?: string[] | ((t: any) => boolean);
+  predecessors?: string[] | ((t: any) => string[]);
+  activityId?: string[] | ((t: any) => string);
+}
+
+export interface RelationshipResolvers {
+  source: string[] | ((r: any) => string);
+  target: string[] | ((r: any) => string);
+  type: string[] | ((r: any) => string);
+  lagHours?: string[] | ((r: any) => number);
+}
+
+export interface WbsResolvers {
+  id: string[] | ((w: any) => string);
+  parentId?: string[] | ((w: any) => string | null);
+  name: string[] | ((w: any) => string);
+}
+
+export interface FieldMap {
+  task: FieldResolvers;
+  rel: RelationshipResolvers;
+  wbs: WbsResolvers;
+}
+
+export const defaultFieldMap: FieldMap = {
+  task: {
+    id: ['task_id'],
+    name: ['task_name'],
+    wbsId: ['wbs_id'],
+    start: ['act_start_date', 'early_start_date', 'target_start_date'],
+    finish: ['act_end_date', 'early_end_date', 'target_end_date'],
+    durationDays: ['task_drtn_days'],
+    durationHours: ['target_drtn_hr_cnt', 'orig_duration_hr_cnt'],
+    percentComplete: ['phys_complete_pct'],
+    critical: ['critical_path'],
+    predecessors: ['predecessors'],
+    activityId: ['activity_id']
+  },
+  rel: {
+    source: ['pred_task_id'],
+    target: ['task_id'],
+    type: ['pred_type'],
+    lagHours: ['lag_hr_cnt']
+  },
+  wbs: {
+    id: ['wbs_id'],
+    parentId: ['parent_wbs_id'],
+    name: ['wbs_name']
+  }
+};
+
+export type NormalizedTask = {
+  id: string;
+  name: string;
+  wbsId: string;
+  start: number;
+  finish: number;
+  duration: number; // in days
+  percentComplete?: number;
+  critical?: boolean;
+  predecessors: string[];
+  activityId?: string;
+};
+
+export type NormalizedRelationship = {
+  source: string;
+  target: string;
+  type: string; // FS, SS, FF, SF
+  lag: number; // in hours
+};
+
+export type NormalizedWbs = {
+  id: string;
+  parentId: string | null;
+  name: string;
+};
+
+function resolve<T>(obj: any, r: string[] | ((o: any) => T) | undefined): T | undefined {
+  if (!r) return undefined as any;
+  if (Array.isArray(r)) {
+    for (const key of r) {
+      const v = obj[key];
+      if (v !== undefined && v !== null && v !== '') return v as T;
+    }
+    return undefined as any;
+  }
+  return (r as any)(obj);
+}
+
+function parseDate(v: any): number | undefined {
+  if (!v) return undefined;
+  if (v instanceof Date) return v.getTime();
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') {
+    const iso = v.includes('T') ? v : v.replace(' ', 'T');
+    const d = Date.parse(iso);
+    if (isNaN(d)) return undefined;
+    return d;
+  }
+  return undefined;
+}
+
+function toNumber(v: any): number | undefined {
+  if (v === undefined || v === null || v === '') return undefined;
+  const n = typeof v === 'number' ? v : parseFloat(v);
+  return isNaN(n) ? undefined : n;
+}
+
+function normalizeRelType(t: string): string {
+  if (!t) return t;
+  const idx = t.lastIndexOf('_');
+  return idx === -1 ? t : t.slice(idx + 1);
+}
+
+export function mergeFieldMap(partial?: Partial<FieldMap>): FieldMap {
+  if (!partial) return JSON.parse(JSON.stringify(defaultFieldMap));
+  const res: FieldMap = {
+    task: { ...defaultFieldMap.task, ...(partial.task || {}) },
+    rel: { ...defaultFieldMap.rel, ...(partial.rel || {}) },
+    wbs: { ...defaultFieldMap.wbs, ...(partial.wbs || {}) }
+  };
+  return res;
+}
+
+export interface NormalizeOptions {
+  hoursPerDay?: number;
+}
+
+export function normalizeTasks(raw: any[], map: FieldResolvers, opts: NormalizeOptions = {}): NormalizedTask[] {
+  const hoursPerDay = opts.hoursPerDay ?? 8;
+  return raw.map((t) => {
+    const id = resolve<string>(t, map.id)!;
+    const name = resolve<string>(t, map.name)!;
+    const wbsId = resolve<string>(t, map.wbsId)!;
+    const startVal = resolve<any>(t, map.start);
+    const finishVal = resolve<any>(t, map.finish);
+    const start = parseDate(startVal) ?? 0;
+    const finish = parseDate(finishVal) ?? start;
+    const dDays = toNumber(resolve<any>(t, map.durationDays));
+    const dHours = toNumber(resolve<any>(t, map.durationHours));
+    const duration = dDays !== undefined ? dDays : (dHours !== undefined ? dHours / hoursPerDay : 0);
+    const pc = toNumber(resolve<any>(t, map.percentComplete));
+    const critVal = resolve<any>(t, map.critical);
+    const critical = critVal === undefined ? undefined : Boolean(critVal);
+    const preds = resolve<string[]>(t, map.predecessors) ?? [];
+    const activityId = resolve<string>(t, map.activityId);
+    return {
+      id,
+      name,
+      wbsId,
+      start,
+      finish,
+      duration,
+      percentComplete: pc,
+      critical,
+      predecessors: preds,
+      activityId
+    };
+  });
+}
+
+export function normalizeRelationships(raw: any[], map: RelationshipResolvers): NormalizedRelationship[] {
+  return raw.map((r) => {
+    const source = resolve<string>(r, map.source)!;
+    const target = resolve<string>(r, map.target)!;
+    const typeRaw = resolve<string>(r, map.type)!;
+    const type = normalizeRelType(typeRaw);
+    const lag = toNumber(resolve<any>(r, map.lagHours)) ?? 0;
+    return { source, target, type, lag };
+  });
+}
+
+export function normalizeWbs(raw: any[], map: WbsResolvers): NormalizedWbs[] {
+  return raw.map((w) => {
+    const id = resolve<string>(w, map.id)!;
+    const parentId = resolve<string | null>(w, map.parentId) ?? null;
+    const name = resolve<string>(w, map.name)!;
+    return { id, parentId, name };
+  });
+}
+
+export interface NormalizedSnapshot {
+  tasks: NormalizedTask[];
+  wbs: NormalizedWbs[];
+  relationships: NormalizedRelationship[];
+  metadata?: any;
+}
+
+export function normalizeSnapshot(snapshot: any, map: FieldMap, opts: NormalizeOptions = {}): NormalizedSnapshot {
+  const tasks = normalizeTasks(snapshot.tasks || [], map.task, opts);
+  const wbs = normalizeWbs(snapshot.wbs || [], map.wbs);
+  const relationships = normalizeRelationships(snapshot.relationships || [], map.rel);
+  return { tasks, wbs, relationships, metadata: snapshot.metadata };
+}
+
+export type ValidationIssue = {
+  level: 'error' | 'warn';
+  message: string;
+};
+
+export interface ValidationReport {
+  valid: boolean;
+  issues: ValidationIssue[];
+}
+
+export function validateSnapshot(snapshot: any, map: FieldMap): ValidationReport {
+  const issues: ValidationIssue[] = [];
+  const tasks = snapshot.tasks || [];
+  for (const t of tasks) {
+    const id = resolve<string>(t, map.task.id);
+    if (!id) issues.push({ level: 'error', message: 'Task missing id' });
+    const name = resolve<string>(t, map.task.name);
+    if (!name) issues.push({ level: 'warn', message: `Task ${id ?? '?'} missing name` });
+  }
+  const rels = snapshot.relationships || [];
+  for (const r of rels) {
+    const src = resolve<string>(r, map.rel.source);
+    const tgt = resolve<string>(r, map.rel.target);
+    if (!src || !tgt) {
+      issues.push({ level: 'warn', message: 'Relationship missing endpoints' });
+    }
+  }
+  return { valid: !issues.some(i => i.level === 'error'), issues };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,123 @@
+export type GanttronMode = 'view' | 'compare';
+
+export interface MetronSnapshot {
+  [key: string]: any;
+}
+
+export interface CompareInput {
+  baseline: MetronSnapshot;
+  update: MetronSnapshot;
+}
+
+export interface GanttronOptions {
+  container: HTMLElement;
+  mode: GanttronMode;
+  data: MetronSnapshot | CompareInput;
+  fieldMap?: Partial<FieldMap>;
+  hoursPerDay?: number;
+  baselineMatch?: 'task_id' | 'activity_id' | 'name_wbs';
+  initialZoom?: 'day' | 'week' | 'month' | 'quarter';
+  leftPaneWidth?: number;
+  rowHeight?: number;
+  showLinks?: boolean;
+  showBaseline?: boolean;
+  theme?: Partial<Record<string, string>>;
+  locale?: string;
+  dateFormat?: Intl.DateTimeFormatOptions;
+  nonWorking?: { weekdays?: number[]; dates?: string[] };
+  onTaskHover?: (taskId: string) => void;
+  onRowFocus?: (taskId: string) => void;
+  onError?: (e: Error) => void;
+}
+
+export interface GanttronInstance {
+  destroy(): void;
+  setZoom(z: 'day' | 'week' | 'month' | 'quarter'): void;
+  resizeLeftPane(px: number): void;
+  setShowLinks(show: boolean): void;
+  setShowBaseline(show: boolean): void;
+  scrollToTask(taskId: string): void;
+  updateData(data: MetronSnapshot | CompareInput): void;
+  updateFieldMap(map: Partial<FieldMap>): void;
+  highlightCritical(on: boolean): void;
+  filter(predicate: (t: any) => boolean): void;
+  clearFilter(): void;
+  expandAll(): void;
+  collapseAll(): void;
+  toPNG(): Promise<Blob>;
+  toSVG(): string;
+  fit(target: 'tasks' | 'range' | 'all'): void;
+}
+
+import {
+  FieldMap,
+  mergeFieldMap,
+  normalizeSnapshot,
+  NormalizedSnapshot,
+  validateSnapshot,
+} from './adapters/field-map.js';
+
+class Ganttron implements GanttronInstance {
+  private options: GanttronOptions;
+  private fieldMap: FieldMap;
+  private data: NormalizedSnapshot | { baseline: NormalizedSnapshot; update: NormalizedSnapshot };
+
+  constructor(opts: GanttronOptions) {
+    this.options = opts;
+    this.fieldMap = mergeFieldMap(opts.fieldMap);
+    this.data = this.normalizeInput(opts.data);
+    const report = validateSnapshot('baseline' in this.data ? this.data.update : this.data, this.fieldMap);
+    if (!report.valid && this.options.onError) {
+      this.options.onError(new Error('Snapshot validation failed'));
+    }
+    // Rendering is out of scope for this stub implementation.
+  }
+
+  private normalizeInput(data: MetronSnapshot | CompareInput) {
+    if (this.options.mode === 'compare') {
+      const cmp = data as CompareInput;
+      return {
+        baseline: normalizeSnapshot(cmp.baseline, this.fieldMap, { hoursPerDay: this.options.hoursPerDay }),
+        update: normalizeSnapshot(cmp.update, this.fieldMap, { hoursPerDay: this.options.hoursPerDay }),
+      };
+    }
+    return normalizeSnapshot(data as MetronSnapshot, this.fieldMap, { hoursPerDay: this.options.hoursPerDay });
+  }
+
+  destroy(): void {}
+  setZoom(): void {}
+  resizeLeftPane(): void {}
+  setShowLinks(): void {}
+  setShowBaseline(): void {}
+  scrollToTask(): void {}
+  updateData(data: MetronSnapshot | CompareInput): void {
+    this.data = this.normalizeInput(data);
+  }
+  updateFieldMap(map: Partial<FieldMap>): void {
+    this.fieldMap = mergeFieldMap(map);
+    this.data = this.normalizeInput(this.options.data);
+  }
+  highlightCritical(): void {}
+  filter(): void {}
+  clearFilter(): void {}
+  expandAll(): void {}
+  collapseAll(): void {}
+  async toPNG(): Promise<Blob> {
+    throw new Error('toPNG not implemented in stub');
+  }
+  toSVG(): string {
+    return '<svg></svg>';
+  }
+  fit(): void {}
+}
+
+export function createGanttron(opts: GanttronOptions): GanttronInstance {
+  return new Ganttron(opts);
+}
+
+export {
+  FieldMap,
+  mergeFieldMap,
+  normalizeSnapshot,
+  validateSnapshot,
+} from './adapters/field-map.js';

--- a/test/field-map.test.ts
+++ b/test/field-map.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { mergeFieldMap, normalizeSnapshot } from '../src/adapters/field-map.js';
+
+const sample = {
+  metadata: { schedule_id: 3, data_date: '2021-11-08' },
+  tasks: [
+    {
+      task_id: '1',
+      task_name: 'Task A',
+      wbs_id: 'w1',
+      act_start_date: '2023-08-02 08:00',
+      act_end_date: '2023-08-03 17:00',
+      task_drtn_days: 1,
+      phys_complete_pct: '50',
+      critical_path: true,
+      predecessors: ['0']
+    }
+  ],
+  wbs: [
+    { wbs_id: 'w1', wbs_name: 'Root', parent_wbs_id: null }
+  ],
+  relationships: [
+    { pred_task_id: '0', task_id: '1', pred_type: 'PR_FS', lag_hr_cnt: 0 }
+  ]
+};
+
+describe('field map normalization', () => {
+  it('normalizes snapshot with default map', () => {
+    const map = mergeFieldMap();
+    const normalized = normalizeSnapshot(sample, map);
+    expect(normalized.tasks).toHaveLength(1);
+    const t = normalized.tasks[0];
+    expect(t.id).toBe('1');
+    expect(t.name).toBe('Task A');
+    expect(t.duration).toBe(1);
+    expect(t.critical).toBe(true);
+    expect(t.predecessors).toEqual(['0']);
+    expect(t.start).toBeTypeOf('number');
+    expect(normalized.relationships[0].type).toBe('FS');
+  });
+
+  it('supports custom field aliases and resolver functions', () => {
+    const snapshot = {
+      tasks: [
+        { id: 't', name: 'Custom', wbs: 'w', start: '2023-01-01 00:00', end: '2023-01-02 00:00', hours: 8 }
+      ],
+      wbs: [],
+      relationships: []
+    };
+    const map = mergeFieldMap({
+      task: {
+        id: ['id'],
+        name: ['name'],
+        wbsId: ['wbs'],
+        start: ['start'],
+        finish: ['end'],
+        durationHours: ['hours']
+      }
+    });
+    const normalized = normalizeSnapshot(snapshot, map);
+    expect(normalized.tasks[0].duration).toBe(1);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- implement schema-evolution-safe field map with normalization utilities
- scaffold Ganttron API with stub methods and validation
- add tests and build configuration for TypeScript project

## Testing
- `npm run build`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ae72b4b4832ca0e33df95d55e2c5